### PR TITLE
Make buildable on alpine

### DIFF
--- a/src/ulist.c
+++ b/src/ulist.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <sys/types.h>
 
 #include "ulist.h"
 #include "error.h"


### PR DESCRIPTION
I couldn't build it on alpine linux, did some digging around and it turns out that since alpine uses musl as a standard library implementation, imports are handled differently, this won't affect functionality, it will just be compatible with alpine and potentially other musl-based distros