### PR TITLE
Add MacPorts info to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ AUR package.
 yay -S ctpv-git
 ```
 
+### MacPorts
+
+With MacPorts, you can install the
+[`ctpv`](https://ports.macports.org/port/ctpv)
+package.
+
+```console
+sudo port install ctpv
+```
+
 ## Integration
 
 ### lf file manager


### PR DESCRIPTION
Following on [earlier request](https://github.com/NikitaIvanovV/ctpv/issues/34#issuecomment-1492724070); added installation instructions for MacPorts package.